### PR TITLE
chore(time): add now_secs helper

### DIFF
--- a/src/civ_backend/Cargo.toml
+++ b/src/civ_backend/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 candid = "0.10"
 ic-cdk = "0.18.5"
-ic-cdk-timers = "0.12.2" # Feel free to remove this dependency if you don't need timers
+ic-cdk-timers = "0.12.2" # Feel free to remove this dependency if you don't need timersy
+
 serde = { version = "1.0", features = ["derive"] }
 ic-cdk-macros = "0.18.5"

--- a/src/civ_backend/src/time.rs
+++ b/src/civ_backend/src/time.rs
@@ -1,0 +1,7 @@
+// Time utilities (seconds precision)
+pub fn now_secs() -> u64 {
+    ic_cdk::api::time() / 1_000_000_000
+}
+
+
+


### PR DESCRIPTION
Added now_secs helper function, will be used throughout backend.
It converts unix nanoseconds to seconds.